### PR TITLE
Add home button and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <title>Singaseong Pinball</title>
+  <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+  <link rel="icon" href="src/favicon.ico">
+  <link rel="manifest" href="src/site.webmanifest">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <a id="homeBtn" href="https://singaseongj.github.io/">Home</a>
   <h1>Singaseong Pinball</h1>
   <div id="menu">
     <button id="startBtn">Start Game</button>

--- a/src/site.webmanifest
+++ b/src/site.webmanifest
@@ -1,1 +1,20 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Singaseong Pinball",
+  "short_name": "Pinball",
+  "icons": [
+    {
+      "src": "android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}
+

--- a/style.css
+++ b/style.css
@@ -6,6 +6,22 @@ body {
   padding: 0;
 }
 
+#homeBtn {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  padding: 5px 10px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: #333;
+  text-decoration: none;
+}
+
+#homeBtn:hover {
+  background: #e9e9e9;
+}
+
 #game {
   background: #111;
   border: 2px solid #444;


### PR DESCRIPTION
## Summary
- Add top-left Home button linking to main website.
- Wire up favicon assets and web manifest for better branding.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1251cdf1c832aa3e4fa6e9cd51350