### PR TITLE
Add service worker and layout container for pinball game

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,22 +10,30 @@
   <link rel="manifest" href="src/site.webmanifest">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <a id="homeBtn" href="https://singaseongj.github.io/">Home</a>
-  <h1>Singaseong Pinball</h1>
-  <div id="menu">
-    <button id="startBtn">Start Game</button>
-    <button id="highscoreBtn">High Scores</button>
-  </div>
-  <div id="scoreboard" class="hidden">
-    <h2>High Scores</h2>
-    <ol id="scores"></ol>
-    <button id="closeScore">Close</button>
-  </div>
-  <div id="gameArea" class="hidden">
-    <canvas id="game" width="400" height="600"></canvas>
-    <div id="scoreWrap">Score: <span id="score">0</span></div>
+<body oncontextmenu="return false;">
+  <div class="background"></div>
+  <div id="content">
+    <a id="homeBtn" href="https://singaseongj.github.io/">Home</a>
+    <h1>Singaseong Pinball</h1>
+    <div id="menu">
+      <button id="startBtn">Start Game</button>
+      <button id="highscoreBtn">High Scores</button>
+    </div>
+    <div id="scoreboard" class="hidden">
+      <h2>High Scores</h2>
+      <ol id="scores"></ol>
+      <button id="closeScore">Close</button>
+    </div>
+    <div id="gameArea" class="hidden">
+      <canvas id="game" width="400" height="600"></canvas>
+      <div id="scoreWrap">Score: <span id="score">0</span></div>
+    </div>
   </div>
   <script src="pinball.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('worker.js');
+    }
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,37 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  touch-action: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
 body {
   font-family: Arial, sans-serif;
   text-align: center;
   background: #f0f0f0;
+}
+
+#content {
+  position: fixed;
+  height: 100%;
+  width: 100%;
   margin: 0;
   padding: 0;
+  z-index: 99;
+}
+
+.background {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: -1;
 }
 
 #homeBtn {

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,35 @@
+const filesToCache = [
+  "Pinball.htm",
+  "Pinball.json",
+  "Pinball.png",
+  "PinballFavIcon_16x16.png",
+  "PinballFavIcon_192x192.png",
+  "PinballFavIcon_512x512.png",
+  "PinballGame.htm",
+  "PinballGame.js",
+  "PinballShare.png"
+];
+
+const staticCacheName = "Pinball-v1";
+
+self.addEventListener("install", event => {
+  event.waitUntil(
+    caches.open(staticCacheName)
+    .then(cache => {
+      return cache.addAll(filesToCache);
+    })
+  );
+});
+
+self.addEventListener("fetch", event => {
+  event.respondWith(
+    caches.match(event.request)
+    .then(response => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request)
+    }).catch(error => {
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- Wrap game UI in full-screen content container and register service worker
- Enhance styles for full-view layout and interaction blocking
- Add offline cache worker for static pinball assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c12bae4754832a8244241be2af922d