### PR TITLE
Center gameplay and add start/high score menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
 </head>
 <body>
   <a class="home-button" href="https://singaseongj.github.io/">Home</a>
-  <div class="container">
+  <div class="menu">
+    <button id="start-game">Start</button>
+    <button id="show-highscores">High Scores</button>
+  </div>
+  <div class="container hidden">
     <div class="score current-score">score<br><span></span></div>
     <div class="score high-score">high score<br><span></span></div>
     <button class="trigger left-trigger">tap!</button>
@@ -25,6 +29,13 @@
           <ol id="leaderboard-list"></ol>
         </div>
       </div>
+    </div>
+  </div>
+  <div id="highscore-modal" class="highscore-modal hidden">
+    <div class="highscore-modal-content">
+      <h2>High Scores</h2>
+      <ol id="highscore-list"></ol>
+      <button id="close-highscore">Close</button>
     </div>
   </div>
   <script src="pinball.js"></script>

--- a/pinball.js
+++ b/pinball.js
@@ -331,6 +331,20 @@
       .catch(err => console.error('Error fetching leaderboard:', err));
   }
 
+  function showHighScores() {
+    fetch(LEADERBOARD_URL)
+      .then(res => res.json())
+      .then(data => {
+        let list = $('#highscore-list');
+        list.empty();
+        data.scores.forEach(s => {
+          list.append(`<li>${s.name}: ${s.score}</li>`);
+        });
+        $('#highscore-modal').removeClass('hidden');
+      })
+      .catch(err => console.error('Error fetching leaderboard:', err));
+  }
+
   function rand(min, max) {
     return Math.random() * (max - min) + min;
   }
@@ -405,5 +419,17 @@
     });
   }
 
-  load();
+  $('#start-game').on('click', () => {
+    $('.menu').addClass('hidden');
+    $('.container').removeClass('hidden');
+    load();
+  });
+
+  $('#show-highscores').on('click', () => {
+    showHighScores();
+  });
+
+  $('#close-highscore').on('click', () => {
+    $('#highscore-modal').addClass('hidden');
+  });
 })();

--- a/style.css
+++ b/style.css
@@ -12,9 +12,9 @@ html, body {
 body {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   align-items: center;
   margin: 0;
-  padding-top: 60px;
   color: #dee2e6;
   background-color: #212529;
   font-family: 'Hind', sans-serif;
@@ -51,6 +51,28 @@ body {
   left: 10px;
   color: inherit;
   text-decoration: none;
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.menu button {
+  appearance: none;
+  width: 120px;
+  height: 40px;
+  border: 0;
+  border-radius: 5px;
+  background-color: #e64980;
+  color: inherit;
+  font-size: 1rem;
+  text-transform: inherit;
+  cursor: pointer;
+  user-select: none;
+  outline: none;
 }
 
 .trigger {
@@ -101,6 +123,24 @@ canvas {
 }
 
 .game-over-content {
+  text-align: center;
+}
+
+.highscore-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-transform: none;
+}
+
+.highscore-modal-content {
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Center entire app and add main menu with Start and High Scores buttons
- Load game only after pressing Start
- Fetch and display leaderboard in a modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c138f94fa0832ab33aff447f3511ad