### PR TITLE
Disable A and D game controls

### DIFF
--- a/PinballGame.htm
+++ b/PinballGame.htm
@@ -30,7 +30,20 @@
 	<body>
 		<div class="background"></div>
 		<div class="pleasewait" id="loading"><div class="lds-spinner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>
-		<div id="content" oncontextmenu="return false;"></div>
-		<script src="PinballGame.js"></script>
-	</body>
+        <div id="content" oncontextmenu="return false;"></div>
+        <script>
+          window.addEventListener(
+            "keydown",
+            (e) => {
+              if (e.code === "KeyA" || e.code === "KeyD") {
+                if (e.target.tagName !== "INPUT" && e.target.tagName !== "TEXTAREA") {
+                  e.stopPropagation();
+                }
+              }
+            },
+            true
+          );
+        </script>
+        <script src="PinballGame.js"></script>
+        </body>
 </html>


### PR DESCRIPTION
## Summary
- Prevent `KeyA` and `KeyD` from propagating to the game so they can be used in name inputs.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c26e277118832ab36d79fb2c3e7621