### PR TITLE
Stop capturing unused A and D keys

### DIFF
--- a/PinballGame.htm
+++ b/PinballGame.htm
@@ -36,12 +36,9 @@
             "keydown",
             (e) => {
               if (e.code === "KeyA" || e.code === "KeyD") {
-                if (e.target.tagName !== "INPUT" && e.target.tagName !== "TEXTAREA") {
-                  e.stopPropagation();
-                }
+                e.stopPropagation();
               }
-            },
-            true
+            }
           );
         </script>
         <script src="PinballGame.js"></script>


### PR DESCRIPTION
## Summary
- Prevent PinballGame from intercepting `a` and `d` keyboard events so they remain usable in text inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c272f28928832aa3460c1d8d800d08