### PR TITLE
Silence Canvas readback warnings with context override

### DIFF
--- a/PinballGame.htm
+++ b/PinballGame.htm
@@ -68,6 +68,18 @@
         }
       });
     </script>
+    <script>
+      (function() {
+        const originalGetContext = HTMLCanvasElement.prototype.getContext;
+        HTMLCanvasElement.prototype.getContext = function(type, options) {
+          if (type === "2d") {
+            options = options || {};
+            options.willReadFrequently = true;
+          }
+          return originalGetContext.call(this, type, options);
+        };
+      })();
+    </script>
     <script src="PinballGame.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Override HTMLCanvasElement.getContext for 2D contexts to set `willReadFrequently` and avoid console warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6b7ae761c832a955ade0e44e75ccd